### PR TITLE
Log out requests received, in progress, and completed

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,15 +8,16 @@ import (
 
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+
 	fthealth "github.com/Financial-Times/go-fthealth"
 	"github.com/Financial-Times/message-queue-go-producer/producer"
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
-	"io"
-	"io/ioutil"
-	"net/url"
 )
 
 func main() {
@@ -83,6 +84,10 @@ type createJobRequest struct {
 	IDS           []string `json:"ids"`
 }
 
+func (j createJobRequest) String() string {
+	return fmt.Sprintf("Concept=%s URL=%s Throttle=%d", j.Concept, j.URL, j.Throttle)
+}
+
 type job struct {
 	JobID string `json:"jobId"`
 }
@@ -95,6 +100,10 @@ type jobStatus struct {
 	Count    int      `json:"count"`
 	Done     int      `json:"done"`
 	Status   string   `json:"status"`
+}
+
+func (j jobStatus) String() string {
+	return fmt.Sprintf("Concept=%s URL=%s Count=%d Throttle=%d Status=%s", j.Concept, j.URL, j.Count, j.Throttle, j.Status)
 }
 
 type handler struct {
@@ -111,6 +120,7 @@ func (h *handler) createJob(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err, http.StatusBadRequest)
 		return
 	}
+	log.Infof("ConceptPublish: Request received %v", jr)
 	if jr.Concept == "" {
 		err := "Concept empty"
 		log.Errorf(err)

--- a/service.go
+++ b/service.go
@@ -60,11 +60,13 @@ func (s *publishService) newJob(concept string, ids []string, baseURL *url.URL, 
 		s.mutex.Lock()
 		s.jobs[jobID] = &jobStatus{Concept: concept, IDS: ids, URL: baseURL.String(), Throttle: throttle, Count: c, Done: 0, Status: "Failed"}
 		s.mutex.Unlock()
+		log.Errorf("Failed: %s", s.jobs[jobID])
 		return jobID
 	}
 	s.mutex.Lock()
 	s.jobs[jobID] = &jobStatus{Concept: concept, IDS: ids, URL: baseURL.String(), Throttle: throttle, Count: c, Done: 0, Status: "In progress"}
 	s.mutex.Unlock()
+	log.Infof("ConceptPublish: In progress %s", s.jobs[jobID])
 	go s.publishConcepts(jobID, concept, ids, baseURL, authorization, throttle)
 
 	return jobID
@@ -135,6 +137,7 @@ func (s *publishService) publishConcepts(jobID string, conceptType string, ids [
 	s.jobs[jobID].Status = "Completed"
 	s.jobs[jobID].Done = count
 	s.mutex.Unlock()
+	log.Infof("ConceptPublish: Completed %s", s.jobs[jobID])
 	return
 }
 


### PR DESCRIPTION
Here's what the logs look like:
time="2016-08-03T15:37:44+01:00" level=info msg="ConceptPublish: Request received Concept=organisations URL=http://localhost:8080/transformers/organisations/ Throttle=100"

time="2016-08-03T15:37:44+01:00" level=info msg="ConceptPublish: In progress Concept=organisations URL=http://127.0.0.1:60179/ Count=2 Throttle=1 Status=In progress"

time="2016-08-03T15:37:46+01:00" level=info msg="ConceptPublish: Completed Concept=organisations URL=http://127.0.0.1:60179/ Count=2 Throttle=1 Status=Completed"
