### PR TITLE
HTTP Sender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.iml
 concept-publisher
 .idea/
+...

--- a/healthcheck_handler.go
+++ b/healthcheck_handler.go
@@ -4,28 +4,38 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	fthealth "github.com/Financial-Times/go-fthealth"
-	log "github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
+
+	"net/url"
+
+	fthealth "github.com/Financial-Times/go-fthealth"
+	log "github.com/Sirupsen/logrus"
 )
 
 type healthcheckHandler struct {
-	kafkaPAddr string
-	topic      string
-	httpClient *http.Client
+	kafkaPAddr   string
+	topic        string
+	httpClient   *http.Client
+	httpEndpoint string
 }
 
-func newHealthcheckHandler(topic string, kafkaPAddr string, httpClient *http.Client) healthcheckHandler {
+func newHealthcheckHandler(topic string, kafkaPAddr string, httpClient *http.Client, httpEndpoint string) healthcheckHandler {
 	return healthcheckHandler{
-		kafkaPAddr: kafkaPAddr,
-		topic:      topic,
-		httpClient: httpClient,
+		kafkaPAddr:   kafkaPAddr,
+		topic:        topic,
+		httpClient:   httpClient,
+		httpEndpoint: httpEndpoint,
 	}
 }
 
 func (h *healthcheckHandler) health() func(w http.ResponseWriter, r *http.Request) {
-	return fthealth.Handler("Dependent services healthcheck", "Services: kafka-rest-proxy", h.canConnectToProxyHealthcheck())
+
+	if h.kafkaPAddr != "" {
+		return fthealth.Handler("Dependent services healthcheck", "Services: kafka-rest-proxy", h.canConnectToProxyHealthcheck())
+	}
+	return fthealth.Handler("Dependent services healthcheck", "Services: http-endpoint", h.canConnectToHttpEndpoint())
+
 }
 
 func (h *healthcheckHandler) gtg(w http.ResponseWriter, r *http.Request) {
@@ -38,10 +48,40 @@ func (h *healthcheckHandler) canConnectToProxyHealthcheck() fthealth.Check {
 	return fthealth.Check{
 		BusinessImpact:   "Forwarding messages to kafka-proxy in coco won't work. Concept publishing won't work.",
 		Name:             "Forward messages to kafka-proxy.",
-		PanicGuide:       "https://sites.google.com/a/ft.com/ft-technology-service-transition/home/run-book-library/concept-publisher",
+		PanicGuide:       "https://dewey.ft.com/concept-publisher.html",
 		Severity:         1,
 		TechnicalSummary: "Forwarding messages is broken. Check if kafka-proxy in coco is reachable.",
 		Checker:          h.checkCanConnectToProxy,
+	}
+}
+
+func (h *healthcheckHandler) canConnectToHttpEndpoint() fthealth.Check {
+	return fthealth.Check{
+		BusinessImpact:   "Forwarding messages to HTTP endpoint will fail. Concept publishing won't work.",
+		Name:             "Forward messages to HTTP endpoint.",
+		PanicGuide:       "https://dewey.ft.com/concept-publisher.html",
+		Severity:         1,
+		TechnicalSummary: "Forwarding messages is broken. Check if HTTP endpoint is reachable.",
+		Checker: func() error {
+			url, err := url.Parse(h.httpEndpoint)
+			url.Path = "/__gtg"
+			if err != nil {
+				return err
+			}
+			req := &http.Request{
+				Method: "GET",
+				URL:    url,
+				Header: http.Header{
+					"Content-Type": {"application/json"},
+				},
+			}
+
+			resp, err := h.httpClient.Do(req)
+			if err != nil || resp.StatusCode != http.StatusOK {
+				return err
+			}
+			return nil
+		},
 	}
 }
 

--- a/http_queue_service.go
+++ b/http_queue_service.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+type httpQueue struct {
+	httpClient *http.Client
+	endpoint   string
+}
+
+func newHttpQueueService(httpClient *http.Client, endpoint string) httpQueue {
+
+	return httpQueue{
+		httpClient: httpClient,
+		endpoint:   endpoint,
+	}
+}
+
+func (q httpQueue) sendMessage(id string, conceptType string, tid string, payload []byte) error {
+
+	url, err := url.Parse(strings.TrimRight(q.endpoint, "/") + "/" + id)
+	if err != nil {
+		log.Errorf("Error generating URL: %s", err)
+		return err
+	}
+	log.Debug(url)
+	req := &http.Request{
+		Method: "PUT",
+		URL:    url,
+		Header: http.Header{
+			"Message-Type":      {conceptType},
+			"Content-Type":      {"application/json"},
+			"X-Request-Id":      {tid},
+			"Origin-System-Id":  {"http://cmdb.ft.com/systems/upp"},
+			"Message-Timestamp": {time.Now().Format(messageTimestampDateFormat)},
+		},
+		Body:          ioutil.NopCloser(bytes.NewBuffer(payload)),
+		ContentLength: int64(len(payload)),
+	}
+
+	resp, err := q.httpClient.Do(req)
+	if err != nil {
+		log.Errorf("Error in making request [%d]: %s", resp.StatusCode, err)
+		return err
+	}
+
+	return nil
+}

--- a/http_queue_service.go
+++ b/http_queue_service.go
@@ -11,13 +11,16 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+type httpClient interface {
+	Do(req *http.Request) (resp *http.Response, err error)
+}
+
 type httpQueue struct {
-	httpClient *http.Client
+	httpClient httpClient
 	endpoint   string
 }
 
-func newHttpQueueService(httpClient *http.Client, endpoint string) httpQueue {
-
+func newHttpQueueService(httpClient httpClient, endpoint string) httpQueue {
 	return httpQueue{
 		httpClient: httpClient,
 		endpoint:   endpoint,

--- a/http_queue_service_test.go
+++ b/http_queue_service_test.go
@@ -54,7 +54,7 @@ func TestHttpQueueServiceBadResponse(t *testing.T) {
 
 func TestNewHttpQueueService(t *testing.T) {
 	actualHQ := newHttpQueueService(&mockHttpClient{}, "endpoint")
-	expectedHQ := httpQueue{&mockHttpClient{}, "endpoint"}
+	expectedHQ := &httpQueue{&mockHttpClient{}, "endpoint"}
 
 	assert.Equal(t, expectedHQ, actualHQ)
 }

--- a/http_queue_service_test.go
+++ b/http_queue_service_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHttpClient struct {
+	resp       string
+	statusCode int
+	err        error
+}
+
+func (c *mockHttpClient) Do(req *http.Request) (resp *http.Response, err error) {
+	cb := ioutil.NopCloser(bytes.NewReader([]byte(c.resp)))
+	return &http.Response{Body: cb, StatusCode: c.statusCode}, c.err
+}
+
+func TestHttpQueueService(t *testing.T) {
+
+	hq := httpQueue{&mockHttpClient{"Success", 200, nil}, "http://localhost/endpoint"}
+
+	err := hq.sendMessage("1", "Brands", "tid_1", []byte{1, 2})
+
+	assert.NoError(t, err)
+
+}
+
+func TestHttpQueueServiceBadURL(t *testing.T) {
+
+	hq := httpQueue{&mockHttpClient{"Failure", 0, nil}, "https://192.16 8.0.2:8080/foo"}
+
+	err := hq.sendMessage("1", "Brands", "tid_1", []byte{1, 2})
+
+	assert.Error(t, err)
+
+}
+
+func TestHttpQueueServiceBadResponse(t *testing.T) {
+
+	hq := httpQueue{&mockHttpClient{"Failure", 404, errors.New("No page found")}, "https://192.168.0.2:8080/foo"}
+
+	err := hq.sendMessage("1", "Brands", "tid_1", []byte{1, 2})
+
+	assert.Error(t, err)
+
+}
+
+func TestNewHttpQueueService(t *testing.T) {
+	actualHQ := newHttpQueueService(&mockHttpClient{}, "endpoint")
+	expectedHQ := httpQueue{&mockHttpClient{}, "endpoint"}
+
+	assert.Equal(t, expectedHQ, actualHQ)
+}

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 
 		var httpCall caller = newHttpCaller(httpClient)
 		var publishService publisher = newPublishService(clusterRouterAddress, &queueService, &httpCall, *gtgRetries)
-		healthHandler := newHealthcheckHandler(*topic, *proxyAddress, httpClient)
+		healthHandler := newHealthcheckHandler(*topic, *proxyAddress, httpClient, *s3RwAddress)
 		pubHandler := newPublishHandler(&publishService)
 		assignHandlers(*port, &pubHandler, &healthHandler)
 	}

--- a/publish_service.go
+++ b/publish_service.go
@@ -249,7 +249,7 @@ func (p publishService) fetchConcepts(theJob *internalJob, authorization string,
 		}
 		data, fail := (*p.httpService).fetchConcept(id, theJob.url+id, authorization)
 		if fail != nil {
-			log.Warnf("coulnd't fetch concept, putting it to failures %v", id)
+			log.Warnf("couldn't fetch concept, putting it to failures %v", id)
 			pushToFailures(fail, failures)
 			continue
 		}

--- a/queue_service.go
+++ b/queue_service.go
@@ -12,8 +12,8 @@ type kafkaQueue struct {
 	producer *producer.MessageProducer
 }
 
-func newQueueService(producer *producer.MessageProducer) kafkaQueue {
-	return kafkaQueue{producer: producer}
+func newQueueService(producer *producer.MessageProducer) queue {
+	return &kafkaQueue{producer: producer}
 }
 
 type queue interface {

--- a/queue_service.go
+++ b/queue_service.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"time"
+
 	"github.com/Financial-Times/message-queue-go-producer/producer"
 	log "github.com/Sirupsen/logrus"
 	"github.com/satori/go.uuid"
-	"time"
 )
 
 type kafkaQueue struct {


### PR DESCRIPTION
Adding a new send endpoint, which allows the publisher to send concepts to an HTTP endpoint instead of directly to Kafka.

