### PR TITLE
Remove kafka topic healthcheck

### DIFF
--- a/healthcheck_handler.go
+++ b/healthcheck_handler.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"net/url"

--- a/healthcheck_handler.go
+++ b/healthcheck_handler.go
@@ -102,7 +102,7 @@ func (h *healthcheckHandler) checkCanConnectToProxy() error {
 }
 
 func (h *healthcheckHandler) checkProxyConnection() ([]byte, error) {
-	//check if proxy is running and topic is present
+	//check if proxy is running
 	req, err := http.NewRequest("GET", h.kafkaPAddr+"/topics", nil)
 	if err != nil {
 		log.Errorf("Error creating new kafka-proxy healthcheck request: %v", err.Error())

--- a/healthcheck_handler.go
+++ b/healthcheck_handler.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"

--- a/healthcheck_handler.go
+++ b/healthcheck_handler.go
@@ -100,7 +100,7 @@ func (h *healthcheckHandler) checkCanConnectToProxy() error {
 		log.Errorf("Healthcheck: Error reading request body: %v", err.Error())
 		return err
 	}
-	return checkIfTopicIsPresent(body, h.topic)
+	return nil
 }
 
 func (h *healthcheckHandler) checkProxyConnection() ([]byte, error) {
@@ -120,18 +120,4 @@ func (h *healthcheckHandler) checkProxyConnection() ([]byte, error) {
 		return nil, fmt.Errorf("Connecting to kafka proxy was not successful. Status: %d", resp.StatusCode)
 	}
 	return ioutil.ReadAll(resp.Body)
-}
-
-func checkIfTopicIsPresent(body []byte, searchedTopic string) error {
-	var topics []string
-	err := json.Unmarshal(body, &topics)
-	if err != nil {
-		return fmt.Errorf("Connection could be established to kafka-proxy, but a parsing error occured and topic could not be found. %v", err.Error())
-	}
-	for _, topic := range topics {
-		if topic == searchedTopic {
-			return nil
-		}
-	}
-	return errors.New("Connection could be established to kafka-proxy, but topic was not found")
 }

--- a/healthcheck_handler.go
+++ b/healthcheck_handler.go
@@ -93,7 +93,7 @@ func (h *healthcheckHandler) checkCanConnectToHttpEndpoint() error {
 }
 
 func (h *healthcheckHandler) checkCanConnectToProxy() error {
-	body, err := h.checkProxyConnection()
+	err := h.checkProxyConnection()
 	if err != nil {
 		log.Errorf("Healthcheck: Error reading request body: %v", err.Error())
 		return err
@@ -101,21 +101,21 @@ func (h *healthcheckHandler) checkCanConnectToProxy() error {
 	return nil
 }
 
-func (h *healthcheckHandler) checkProxyConnection() ([]byte, error) {
+func (h *healthcheckHandler) checkProxyConnection() error {
 	//check if proxy is running
 	req, err := http.NewRequest("GET", h.kafkaPAddr+"/topics", nil)
 	if err != nil {
 		log.Errorf("Error creating new kafka-proxy healthcheck request: %v", err.Error())
-		return nil, err
+		return err
 	}
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
 		log.Errorf("Healthcheck: Error executing kafka-proxy GET request: %v", err.Error())
-		return nil, err
+		return err
 	}
 	defer closeNice(resp)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Connecting to kafka proxy was not successful. Status: %d", resp.StatusCode)
+		return fmt.Errorf("Connecting to kafka proxy was not successful. Status: %d", resp.StatusCode)
 	}
-	return ioutil.ReadAll(resp.Body)
+	return nil
 }


### PR DESCRIPTION
Currently `concept-publisher` alerts in newly provisioned clusters, as the `concept` topic doesn't exist.

Since the topic will be automatically created when a message is pushed, we don't actually care if the topic exists or not - only that we can can connect to Kafka.

This PR removes the topic check from the healthcheck.